### PR TITLE
fix: add React import to shadcn components

### DIFF
--- a/src/ui/shadcn/components/ui/aspect-ratio.tsx
+++ b/src/ui/shadcn/components/ui/aspect-ratio.tsx
@@ -1,9 +1,10 @@
-import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
+import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio";
+import React from "react";
 
 function AspectRatio({
   ...props
 }: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
-  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
 }
 
-export { AspectRatio }
+export { AspectRatio };

--- a/src/ui/shadcn/components/ui/skeleton.tsx
+++ b/src/ui/shadcn/components/ui/skeleton.tsx
@@ -1,4 +1,5 @@
-import { cn } from "@/src/ui/shadcn/lib/utils/index"
+import React from "react";
+import { cn } from "@/src/ui/shadcn/lib/utils/index";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -7,7 +8,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("bg-accent animate-pulse rounded-md", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };


### PR DESCRIPTION
As per Eslint rule for react, the all JSX should import React. Added React import to aspect-ratio.tsx and skeleton.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized imports and formatting for UI components, including explicit React imports and semicolon consistency. No functional or visual changes.
* **Chores**
  * Maintenance updates to align with project conventions and ensure consistent builds and linting.
* **Bug Fixes**
  * None.
* **User Impact**
  * No user-facing changes; behavior and public APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->